### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/vaibhavb/projectlira)](https://repl.it/github/vaibhavb/projectlira)
+
 # Project Lira
 Lira is a demonstration of domain driven voice first programming environment. The domain knowledge of Lira is around the idea of loading data sets and working with them domain specific data science modalities.
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).